### PR TITLE
Add debug_types_sec arg to DWARFInfo in `read_pe`

### DIFF
--- a/dwex/formats.py
+++ b/dwex/formats.py
@@ -73,6 +73,7 @@ def read_pe(filename):
             debug_loclists_sec = data.get('.debug_loclists'),
             debug_rnglists_sec = data.get('.debug_rnglists'),
             debug_sup_sec = data.get('.debug_sup'),
+            debug_types_sec = data.get('.debug_types'),
             gnu_debugaltlink_sec = data.get('.gnu_debugaltlink')
         )
         di._format = 2


### PR DESCRIPTION
The DWARFInfo constructor errors out on any attempt to open an executable because there's an arg missing. It looks like it was added [here](https://github.com/eliben/pyelftools/commit/e405fede71927b1e3f7aae2daa7cf5d1763dc71f).

This is probably necessary for the non-pe formats as well, but I'm on windows so i can't easily test those.