### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
     entry_points={"gui_scripts": ["dwex = dwex.__main__:main"]},
     cmdclass={'install': my_install},
     keywords = ['dwarf', 'debug', 'debugging', 'symbols', 'viewer', 'view', 'browser', 'browse', 'tree'],
-    license="BSD",
+    license="BSD-3-Clause",
     author="Seva Alekseyev",
     author_email="sevaa@sprynet.com",
     description="GUI viewer for DWARF debug information",
@@ -142,7 +142,6 @@ setup(
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Environment :: MacOS X :: Cocoa",
         "Environment :: Win32 (MS Windows)",


### PR DESCRIPTION
Running `python setup.py` shows the following warning. This should fix the warning.

```plain
/usr/lib/python3.13/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
!!

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: BSD License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

!!
  self._finalize_license_expression()
```

For reference:
- [Python Packaging User Guide](https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license)
- [SPDX licenses](https://spdx.org/licenses/)
