### PR TITLE
Fix windows theme

### DIFF
--- a/dwex/__main__.py
+++ b/dwex/__main__.py
@@ -925,6 +925,20 @@ def main():
     from .patch import monkeypatch
     monkeypatch()
 
+    # DWEX is styled for a light theme, but Qt defaults to something "random" based on system settings.
+    # Hacky fix for accidental dark theme in Windows: force the "windowsvista" theme if it exists.
+    styles = QStyleFactory.keys()
+    preferred_styles = ["windowsvista"] # Include additional styles for other OSes if necessary.
+
+    style = None
+    for s in preferred_styles:
+        if s in styles:
+            style = QStyleFactory.create(s)
+            break
+
+    if style:
+        QApplication.setStyle(style)
+
     global the_app
     the_app = TheApp()
     the_app.start()


### PR DESCRIPTION
Currently, DWEX on a dark-themed windows looks like this:

![image](https://github.com/user-attachments/assets/3abde757-cb33-4ae6-bd2a-a67d7c5f2449)

This PR forces a light theme for the application to match the hard-coded styling elements. End result:

![image](https://github.com/user-attachments/assets/570ea727-7d02-4ee9-8622-e86abc9fb732)

I don't expect "windowsvista" to exist on other platforms but if this interferes with other OSes, we can try a different detection method.